### PR TITLE
Use zero as default progress counter rather than blank

### DIFF
--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -28,7 +28,7 @@
         :title="`Score: ${entry.users.get(user.name).score} / 10`"
       >
         <div class="animate">
-          {{ entry.users.get(user.name).progress || "" }}
+          {{ entry.users.get(user.name).progress || "0" }}
         </div>
       </sui-table-cell>
       <sui-table-cell v-else></sui-table-cell>


### PR DESCRIPTION
This very minor fix addresses a very specific scenario in which all
users in the chart have just started a show, are all at zero episodes
watched, but still have the show as "Watching". Currently, this will
result in a blank cell being shown for all users, and the show's
episode count being highlighted green.

This can be confusing if not all users in the chart are watching the
show, since there's no way to differentiate between someone who
doesn't have the show set as "Watching", and someone who does but just
hasn't watched any episodes.

By changing the default counter to "0" from blank, this distinction
can be made, since if a user doesn't have the show in their list, then
the `v-else` will trigger and a blank cell will be shown.